### PR TITLE
feat: switch mermaid theme based on dark/light mode

### DIFF
--- a/src/components/mdoc/Mermaid.tsx
+++ b/src/components/mdoc/Mermaid.tsx
@@ -1,28 +1,36 @@
 import mermaid, { type MermaidConfig } from 'mermaid';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { theme } from '../../store/theme';
 
 interface Props {
 	content: string;
 }
 
-const config: MermaidConfig = {
-	startOnLoad: true,
-	theme: 'dark',
-	gantt: {
-		useMaxWidth: true,
-	},
-};
-
 const Mermaid = ({ content }: Props) => {
+	const [currTheme, setCurrTheme] = useState<'dark' | 'light'>('dark');
 	const isGantt = content.trim().startsWith('gantt');
 
 	useEffect(() => {
-		mermaid.initialize(config);
-		mermaid.contentLoaded();
+		const unsubscribe = theme.subscribe((val) => {
+			setCurrTheme(val);
+		});
+		return () => unsubscribe();
 	}, []);
 
+	useEffect(() => {
+		const config: MermaidConfig = {
+			startOnLoad: true,
+			theme: currTheme === 'dark' ? 'dark' : 'forest',
+			gantt: {
+				useMaxWidth: true,
+			},
+		};
+		mermaid.initialize(config);
+		mermaid.run();
+	}, [currTheme]);
+
 	return (
-		<div className='flex justify-center w-full my-8'>
+		<div className='flex justify-center w-full my-8' key={currTheme}>
 			<div
 				className={`mermaid w-full overflow-x-auto [&>svg]:mx-auto ${
 					isGantt ? '[&>svg]:min-w-[min(100%,600px)]' : ''


### PR DESCRIPTION
Mermaid diagrams now dynamically switch between 'dark' and 'forest' themes based on the site's dark/light mode setting.