### PR TITLE
Normalize nav paths; add hover scale to post preview

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -6,11 +6,19 @@ interface Props {
 }
 
 const isActive = (path: string) => {
-	const pathname = Astro.url.pathname;
-	if (path === '/blog') {
-		return pathname === '/blog' || /^\/blog\/\d+\/?$/.test(pathname);
+	const normalizedPath: string = path === '/' ? path : path.replace(/\/$/, '');
+	const pathname: string = Astro.url.pathname;
+	const normalizedPathname: string =
+		pathname === '/' ? pathname : pathname.replace(/\/$/, '');
+
+	if (normalizedPath === '/blog') {
+		return (
+			normalizedPathname === '/blog' ||
+			/^\/blog\/\d+\/?$/.test(normalizedPathname)
+		);
 	}
-	return pathname === path;
+
+	return normalizedPathname === normalizedPath;
 };
 ---
 <nav class={Astro.props.class}>

--- a/src/components/PostPreview.astro
+++ b/src/components/PostPreview.astro
@@ -30,7 +30,7 @@ const getIcon = (type: keyof typeof icons): string => {
   href={externalUrl ?? `/blog/${id}`}
   class:list={[
     "text-left border-2 border-gray-500 rounded shadow p-3 transition duration-300",
-    "hover:text-primary hover:shadow-xl hover:border-primary",
+    "hover:text-primary hover:shadow-xl hover:border-primary hover:scale-105",
     "focus-visible:text-primary focus-visible:shadow-xl focus-visible:border-primary",
     "dark:border-white",
     "dark:hover:border-primary",


### PR DESCRIPTION
Make Nav.isActive robust to trailing slashes and the root path by normalizing both the input path and Astro.url.pathname before comparing. Keep special handling for /blog so /blog and /blog/<id> still count as active. Also add a subtle zoom effect (hover:scale-105) to PostPreview's hover styles for a smoother interactive feel.