### PR TITLE
Replace BMC link with CoDoc widget

### DIFF
--- a/src/components/Codoc.astro
+++ b/src/components/Codoc.astro
@@ -1,0 +1,2 @@
+<script src="https://codoc.jp/js/cms.js" data-css="rainbow-square" data-usercode="Vkxj1CVung" charset="UTF-8" defer></script>
+<div id="codoc-entry-KFJLTHnfmg" class="codoc-entries" data-without-body="1" data-support-message=""></div>

--- a/src/layouts/post.astro
+++ b/src/layouts/post.astro
@@ -3,6 +3,7 @@ import type { CollectionEntry } from 'astro:content';
 import { getEntry } from 'astro:content';
 import { Icon } from 'astro-icon/components';
 import BaseHead from '@/components/BaseHead.astro';
+import Codoc from '@/components/Codoc.astro';
 import Link from '@/components/mdoc/Link.astro';
 import PostHeader from '@/components/PostHeader.astro';
 import Prose from '@/components/Prose.astro';
@@ -52,16 +53,11 @@ const differentPerspectives: CollectionEntry<'blog'>[] = (
 
     <ShareButtons class="mb-20" blogTitle={content.title} />
 
-    <Link
-      href={PROFILE_PAGE_URLS.bmc}
-      class='flex justify-center flex-col text-center mb-20'
-    >
-      <Icon name="simple-icons:buymeacoffee" class="text-2xl mx-auto mb-2" />
-      <span class="text-primary font-bold underline underline-offset-8">気に入っていただけたら、<br class="sm:hidden" />サポートもお待ちしております！</span>
-    </Link>
+    <Codoc />
 
-    <RelatedPosts headingText='Related Posts' posts={similarArticles} class="mb-10" />
+    <RelatedPosts headingText='Related Posts' posts={similarArticles} class="mt-15 mb-10" />
 
     <RelatedPosts headingText="Different Perspectives" posts={differentPerspectives} />
   </PostMainLayout>
 </html>
+


### PR DESCRIPTION
Remove the BuyMeACoffee link and icon block and replace it with a CoDoc embed div. Add the CoDoc CMS script and adjust RelatedPosts spacing (add mt-15). This integrates the CoDoc support widget and tweaks layout spacing accordingly.